### PR TITLE
fix: 탭 이벤트는 시간 저장 안되는현상 해결

### DIFF
--- a/lib/component/when2yapp_time_table.dart
+++ b/lib/component/when2yapp_time_table.dart
@@ -257,6 +257,7 @@ class _When2YappTimeTableCellState extends State<_When2YappTimeTableCell> {
         onTapDown: (_) {
           setState(() {
             selected = !selected;
+            widget.updateSelectedDateTimesCallback?.call(widget.startTime);
           });
         },
         child: SizedBox(


### PR DESCRIPTION
- 드래그는 시간 저장 되는데, 탭은 시간 저장 안되는 현상 해결